### PR TITLE
Update qtl.R

### DIFF
--- a/R/qtl.R
+++ b/R/qtl.R
@@ -194,14 +194,17 @@ SIMQTL <- function (cross, numeric.chr.format=TRUE, method="em",
       
       ## Estimate allele effects by multiple linear regression model
       fit.lm <- stats::lm(cross[["pheno"]][[pheno.col]]  ~ X)
-      summary.fit <- summary(fit.lm)
-      signif.coeff <- as.matrix(summary.fit$coefficients[,1][summary.fit$coefficients[,4] < alpha[2]])
-      rownames(signif.coeff) <- substr(rownames(signif.coeff), start=2, stop=nchar(signif.coeff))
+      coeff <- fit.lm$coefficients[-1]
+      names(coeff) <- substr(names(coeff), start=2, stop=nchar(names(coeff)))
+      if(!is.na(alpha[2])){
+        summary.fit <- summary(fit.lm)$coefficient
+        rownames(summary.fit)[-1] <- substr(rownames(summary.fit)[-1], start=2, stop=nchar(rownames(summary.fit)[-1]))
+        coeff <- as.matrix(summary.fit[,1][summary.fit[,4] < alpha[2]])
+      } 
       
       allelic.effects <- data.frame(predictor=colnames(joinMap2designMatrix(jm=jm, verbose=0))[-1], effect=0)
-      
-      for(i in 1:nrow(signif.coeff)){
-        allelic.effects[allelic.effects$predictor %in% rownames(signif.coeff)[i], "effect"] <- signif.coeff[i]
+      for(i in 1:length(coeff)){
+        allelic.effects[allelic.effects$predictor %in% rownames(coeff)[i], "effect"] <- coeff[i]
       }
       
     } else { # There is no QTL found


### PR DESCRIPTION
If 2nd element of alpha (error rate) is NA, makes no selection on linear regression for allelic effects in SIMQTL